### PR TITLE
Proposal to make pageMargin work on IOS

### DIFF
--- a/viewpager/ViewPager.js
+++ b/viewpager/ViewPager.js
@@ -25,9 +25,6 @@ export default class ViewPager extends Component {
         onPageSelected: null,
         onPageScrollStateChanged: null,
         currentPage: 0,
-        /**
-         * iOS not support yet
-         */
         pageMargin: 0
     };
 
@@ -85,11 +82,15 @@ export default class ViewPager extends Component {
             scrollEventThrottle: needMonitorScroll ? ( this.props.onPageScroll ? 8 : 1) : 0,
         };
         if (needMonitorTouch) props = Object.assign(props, this._panResponder.panHandlers);
+        const scrollViewStyle = {
+          overflow: 'visible',
+          marginHorizontal: -this.props.pageMargin / 2,
+        };
         if (this.props.style && !this.props.style.height)
-            return <ScrollView {...props}/>;
+            return <ScrollView {...props} style={[this.props.style, scrollViewStyle]}/>;
         else return (
             <View style={this.props.style}>
-                <ScrollView {...props} style={null}/>
+                <ScrollView {...props} style={scrollViewStyle}/>
             </View>
         );
     }


### PR DESCRIPTION
Hey, zbtang seems to be unavailable so I'm suggesting how to add page margin to ios here.
Thanks for continuing the component, it really helped me.

This commit simply add styles to ScrollView in order to make pageMaring work.
    * overflow visible makes next border card visible (in case margin is negative)
    * marginHorizontal -pageMargin / 2 makes margin equal balanced on each side of each child